### PR TITLE
add simulation mode using tensor network with nvidia gpus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ uvicorn==0.32.0
 pydantic==2.9.2
 stim==1.13.0
 qiskit==1.2.4
-qiskit-aer==0.15.1
+#qiskit-aer==0.15.1
+qiskit-aer-gpu==0.15.1
 pymatching==2.2.2
 numpy==2.1.2
 python-dateutil==2.9.0

--- a/simulation/qiskit_sim.py
+++ b/simulation/qiskit_sim.py
@@ -1,9 +1,26 @@
 from qiskit_aer import AerSimulator
 from qiskit_aer.noise import NoiseModel, depolarizing_error
 from qiskit import QuantumCircuit
+from qiskit.exceptions import QiskitError
+
+def run_qiskit_simulation(circuit: QuantumCircuit, noise: float = 0.001, shots: int = 1024, method='statevector') -> dict:
+
+    """
+
+    Parameters
+    ----------
+    circuit: QuantumCircuit from qiskit
+    noise: float depolarizing error
+    shots: int number of shots
+    method: configurable with ['statevector', 'tensor_network', ....] Ref: https://qiskit.github.io/qiskit-aer/stubs/qiskit_aer.AerSimulator.html
+            tensor_network mode is only available when nvidia-gpu is detected and through qiskit-aer-gpu.
 
 
-def run_qiskit_simulation(circuit: QuantumCircuit, noise: float = 0.001, shots: int = 1000) -> dict:
+    Returns
+    -------
+
+    """
+
     """
     Run a Qiskit noisy simulation (placeholder).
     """
@@ -13,7 +30,13 @@ def run_qiskit_simulation(circuit: QuantumCircuit, noise: float = 0.001, shots: 
     error_2q = depolarizing_error(noise * 2, 2)
     noise_model.add_all_qubit_quantum_error(error_2q, ['cx', 'swap'])
 
-    simulator = AerSimulator(noise_model=noise_model)
+    simulator = AerSimulator(noise_model=noise_model, method=method)
+
+    try:
+        simulator.set_options(device = "GPU")
+    except QiskitError as e:
+        print(f"qiskit_sim:run_qiskit_simulation, executing on GPU is not support on this device with error {e}")
+
     if not any(instr.operation.name == 'measure' for instr in circuit):
         circuit.measure_all()
 


### PR DESCRIPTION
Adding tensor network simulator method from Qiskit:
* Requires: Nvidia-gpu devices, and qiskit-aer-gpu library.